### PR TITLE
feat(ncv): RO-26984, customize dayOfWeek

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# OpenTable changes
+
+## https://github.com/opentable/HorizonCalendar/pull/2
+- Update validAspectRatioRange of dayOfWeekAspectRatio to be 0.1 -- 3. Default was 0.5 -- 3.
+Sources/Public/CalendarViewContent.swift
+- Make past/future month row in same line with current month row.  
+Introduce a new Bool variable `isCustomizeForOTNewCalendarView` to toggle it.  
+Need to pin the dayOfWeek row when toggle it on.
+Sources/Internal/FrameProvider.swift  
+Sources/Public/CalendarViewContent.swift  
+Sources/Public/CalendarViewRepresentable.swift
+
 # HorizonCalendar
 A declarative, performant, calendar UI component that supports use cases ranging from simple date pickers all the way up to fully-featured calendar apps.
 

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -118,7 +118,7 @@ final class FrameProvider {
     switch monthsLayout {
     case .vertical:
       let monthHeight = heightOfMonth(month, monthHeaderHeight: monthHeaderHeight)
-      let interMonthSpacing = content.isOTNewCalendarView ? -daySize.height : content.interMonthSpacing
+      let interMonthSpacing = content.isCustomizeForOTNewCalendarView ? -daySize.height : content.interMonthSpacing
       return CGPoint(
         x: subsequentMonthOrigin.x,
         y: subsequentMonthOrigin.y - interMonthSpacing - monthHeight)
@@ -143,7 +143,7 @@ final class FrameProvider {
       let previousMonthHeight = heightOfMonth(
         previousMonth,
         monthHeaderHeight: previousMonthHeaderHeight)
-      let interMonthSpacing = content.isOTNewCalendarView ? -daySize.height : content.interMonthSpacing
+      let interMonthSpacing = content.isCustomizeForOTNewCalendarView ? -daySize.height : content.interMonthSpacing
       return CGPoint(
         x: previousMonthOrigin.x,
         y: previousMonthOrigin.y + previousMonthHeight + interMonthSpacing)

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -118,9 +118,10 @@ final class FrameProvider {
     switch monthsLayout {
     case .vertical:
       let monthHeight = heightOfMonth(month, monthHeaderHeight: monthHeaderHeight)
+      let interMonthSpacing = content.isOTNewCalendarView ? -daySize.height : content.interMonthSpacing
       return CGPoint(
         x: subsequentMonthOrigin.x,
-        y: subsequentMonthOrigin.y - content.interMonthSpacing - monthHeight)
+        y: subsequentMonthOrigin.y - interMonthSpacing - monthHeight)
 
     case .horizontal:
       return CGPoint(
@@ -142,9 +143,10 @@ final class FrameProvider {
       let previousMonthHeight = heightOfMonth(
         previousMonth,
         monthHeaderHeight: previousMonthHeaderHeight)
+      let interMonthSpacing = content.isOTNewCalendarView ? -daySize.height : content.interMonthSpacing
       return CGPoint(
         x: previousMonthOrigin.x,
-        y: previousMonthOrigin.y + previousMonthHeight + content.interMonthSpacing)
+        y: previousMonthOrigin.y + previousMonthHeight + interMonthSpacing)
 
     case .horizontal:
       return CGPoint(

--- a/Sources/Internal/FrameProvider.swift
+++ b/Sources/Internal/FrameProvider.swift
@@ -118,9 +118,11 @@ final class FrameProvider {
     switch monthsLayout {
     case .vertical:
       let monthHeight = heightOfMonth(month, monthHeaderHeight: monthHeaderHeight)
+      /// Changes for OTNewCalendarView
       let interMonthSpacing = content.isCustomizeForOTNewCalendarView ? -daySize.height : content.interMonthSpacing
       return CGPoint(
         x: subsequentMonthOrigin.x,
+        /// Changes for OTNewCalendarView
         y: subsequentMonthOrigin.y - interMonthSpacing - monthHeight)
 
     case .horizontal:
@@ -143,9 +145,11 @@ final class FrameProvider {
       let previousMonthHeight = heightOfMonth(
         previousMonth,
         monthHeaderHeight: previousMonthHeaderHeight)
+      /// Changes for OTNewCalendarView
       let interMonthSpacing = content.isCustomizeForOTNewCalendarView ? -daySize.height : content.interMonthSpacing
       return CGPoint(
         x: previousMonthOrigin.x,
+        /// Changes for OTNewCalendarView
         y: previousMonthOrigin.y + previousMonthHeight + interMonthSpacing)
 
     case .horizontal:

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -118,6 +118,16 @@ public final class CalendarViewContent {
     return self
   }
 
+  /// Configures if use for OTNewCalendarView. The default value is `false`.
+  ///
+  /// - Parameters:
+  ///   - isOTNewCalendarView
+  /// - Returns: A mutated `CalendarViewContent` instance with a new inter-month-spacing value.
+  public func isOTNewCalendarView(_ isOTNewCalendarView: Bool) -> CalendarViewContent {
+    self.isOTNewCalendarView = isOTNewCalendarView
+    return self
+  }
+
   /// Configures the amount to inset days and day-of-week items from the edges of a month. The default value is `.zero`.
   ///
   /// - Parameters:
@@ -383,6 +393,7 @@ public final class CalendarViewContent {
   private(set) var dayAspectRatio: CGFloat = 1
   private(set) var dayOfWeekAspectRatio: CGFloat = 1
   private(set) var interMonthSpacing: CGFloat = 0
+  private(set) var isOTNewCalendarView: Bool = false
   private(set) var monthDayInsets: NSDirectionalEdgeInsets = .zero
   private(set) var verticalDayMargin: CGFloat = 0
   private(set) var horizontalDayMargin: CGFloat = 0

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -98,6 +98,7 @@ public final class CalendarViewContent {
   ///   - dayOfWeekAspectRatio: The aspect ratio of each day-of-the-week view.
   /// - Returns: A mutated `CalendarViewContent` instance with a new day-of-the-week aspect ratio value.
   public func dayOfWeekAspectRatio(_ dayOfWeekAspectRatio: CGFloat) -> CalendarViewContent {
+    /// Changes for OTNewCalendarView, the default range was 0.5...3
     let validAspectRatioRange: ClosedRange<CGFloat> = 0.1...3
     assert(
       validAspectRatioRange.contains(dayOfWeekAspectRatio),
@@ -393,6 +394,7 @@ public final class CalendarViewContent {
   private(set) var dayAspectRatio: CGFloat = 1
   private(set) var dayOfWeekAspectRatio: CGFloat = 1
   private(set) var interMonthSpacing: CGFloat = 0
+  /// Changes for OTNewCalendarView
   private(set) var isCustomizeForOTNewCalendarView: Bool = false
   private(set) var monthDayInsets: NSDirectionalEdgeInsets = .zero
   private(set) var verticalDayMargin: CGFloat = 0

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -98,7 +98,7 @@ public final class CalendarViewContent {
   ///   - dayOfWeekAspectRatio: The aspect ratio of each day-of-the-week view.
   /// - Returns: A mutated `CalendarViewContent` instance with a new day-of-the-week aspect ratio value.
   public func dayOfWeekAspectRatio(_ dayOfWeekAspectRatio: CGFloat) -> CalendarViewContent {
-    let validAspectRatioRange: ClosedRange<CGFloat> = 0.5...3
+    let validAspectRatioRange: ClosedRange<CGFloat> = 0.1...3
     assert(
       validAspectRatioRange.contains(dayOfWeekAspectRatio),
       "A day-of-the-week aspect ratio of \(dayOfWeekAspectRatio) will likely cause strange calendar layouts. Only values between \(validAspectRatioRange.lowerBound) and \(validAspectRatioRange.upperBound) should be used.")

--- a/Sources/Public/CalendarViewContent.swift
+++ b/Sources/Public/CalendarViewContent.swift
@@ -121,10 +121,10 @@ public final class CalendarViewContent {
   /// Configures if use for OTNewCalendarView. The default value is `false`.
   ///
   /// - Parameters:
-  ///   - isOTNewCalendarView
+  ///   - isCustomizeForOTNewCalendarView
   /// - Returns: A mutated `CalendarViewContent` instance with a new inter-month-spacing value.
-  public func isOTNewCalendarView(_ isOTNewCalendarView: Bool) -> CalendarViewContent {
-    self.isOTNewCalendarView = isOTNewCalendarView
+  public func isCustomizeForOTNewCalendarView(_ isCustomizeForOTNewCalendarView: Bool) -> CalendarViewContent {
+    self.isCustomizeForOTNewCalendarView = isCustomizeForOTNewCalendarView
     return self
   }
 
@@ -393,7 +393,7 @@ public final class CalendarViewContent {
   private(set) var dayAspectRatio: CGFloat = 1
   private(set) var dayOfWeekAspectRatio: CGFloat = 1
   private(set) var interMonthSpacing: CGFloat = 0
-  private(set) var isOTNewCalendarView: Bool = false
+  private(set) var isCustomizeForOTNewCalendarView: Bool = false
   private(set) var monthDayInsets: NSDirectionalEdgeInsets = .zero
   private(set) var verticalDayMargin: CGFloat = 0
   private(set) var horizontalDayMargin: CGFloat = 0

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -93,7 +93,7 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
   fileprivate var dayAspectRatio: CGFloat?
   fileprivate var dayOfWeekAspectRatio: CGFloat?
   fileprivate var interMonthSpacing: CGFloat?
-  fileprivate var isOTNewCalendarView: Bool?
+  fileprivate var isCustomizeForOTNewCalendarView: Bool?
   fileprivate var monthDayInsets: NSDirectionalEdgeInsets?
   fileprivate var verticalDayMargin: CGFloat?
   fileprivate var horizontalDayMargin: CGFloat?
@@ -147,8 +147,8 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
       content = content.interMonthSpacing(interMonthSpacing)
     }
 
-    if let isOTNewCalendarView {
-      content = content.isOTNewCalendarView(isOTNewCalendarView)
+    if let isCustomizeForOTNewCalendarView {
+      content = content.isCustomizeForOTNewCalendarView(isCustomizeForOTNewCalendarView)
     }
 
     if let monthDayInsets {
@@ -268,11 +268,11 @@ extension CalendarViewRepresentable {
   /// Configures if use for OTNewCalendarView. The default value is `false`.
   ///
   /// - Parameters:
-  ///   - isOTNewCalendarView
+  ///   - isCustomizeForOTNewCalendarView
   /// - Returns: A new `CalendarViewRepresentable` with a new inter-month-spacing value.
-  public func isOTNewCalendarView(_ isOTNewCalendarView: Bool) -> Self {
+  public func isCustomizeForOTNewCalendarView(_ isCustomizeForOTNewCalendarView: Bool) -> Self {
     var view = self
-    view.isOTNewCalendarView = isOTNewCalendarView
+    view.isCustomizeForOTNewCalendarView = isCustomizeForOTNewCalendarView
     return view
   }
 

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -93,6 +93,7 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
   fileprivate var dayAspectRatio: CGFloat?
   fileprivate var dayOfWeekAspectRatio: CGFloat?
   fileprivate var interMonthSpacing: CGFloat?
+  /// Changes for OTNewCalendarView
   fileprivate var isCustomizeForOTNewCalendarView: Bool?
   fileprivate var monthDayInsets: NSDirectionalEdgeInsets?
   fileprivate var verticalDayMargin: CGFloat?
@@ -147,6 +148,7 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
       content = content.interMonthSpacing(interMonthSpacing)
     }
 
+    /// Changes for OTNewCalendarView
     if let isCustomizeForOTNewCalendarView {
       content = content.isCustomizeForOTNewCalendarView(isCustomizeForOTNewCalendarView)
     }

--- a/Sources/Public/CalendarViewRepresentable.swift
+++ b/Sources/Public/CalendarViewRepresentable.swift
@@ -93,6 +93,7 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
   fileprivate var dayAspectRatio: CGFloat?
   fileprivate var dayOfWeekAspectRatio: CGFloat?
   fileprivate var interMonthSpacing: CGFloat?
+  fileprivate var isOTNewCalendarView: Bool?
   fileprivate var monthDayInsets: NSDirectionalEdgeInsets?
   fileprivate var verticalDayMargin: CGFloat?
   fileprivate var horizontalDayMargin: CGFloat?
@@ -144,6 +145,10 @@ public struct CalendarViewRepresentable: UIViewRepresentable {
 
     if let interMonthSpacing {
       content = content.interMonthSpacing(interMonthSpacing)
+    }
+
+    if let isOTNewCalendarView {
+      content = content.isOTNewCalendarView(isOTNewCalendarView)
     }
 
     if let monthDayInsets {
@@ -257,6 +262,17 @@ extension CalendarViewRepresentable {
   public func interMonthSpacing(_ interMonthSpacing: CGFloat) -> Self {
     var view = self
     view.interMonthSpacing = interMonthSpacing
+    return view
+  }
+
+  /// Configures if use for OTNewCalendarView. The default value is `false`.
+  ///
+  /// - Parameters:
+  ///   - isOTNewCalendarView
+  /// - Returns: A new `CalendarViewRepresentable` with a new inter-month-spacing value.
+  public func isOTNewCalendarView(_ isOTNewCalendarView: Bool) -> Self {
+    var view = self
+    view.isOTNewCalendarView = isOTNewCalendarView
     return view
   }
 


### PR DESCRIPTION
- Update validAspectRatioRange of dayOfWeekAspectRatio to be 0.1 -- 3. Default was 0.5 -- 3.
Sources/Public/CalendarViewContent.swift
- Make past/future month row in same line with current month row.  
Introduce a new Bool variable `isCustomizeForOTNewCalendarView` to toggle it.  
Need to pin the dayOfWeek row when toggle it on.
Sources/Internal/FrameProvider.swift  
Sources/Public/CalendarViewContent.swift  
Sources/Public/CalendarViewRepresentable.swift